### PR TITLE
Add missing 'is/are' in improvements output

### DIFF
--- a/extypes/response.go
+++ b/extypes/response.go
@@ -132,9 +132,9 @@ func (s *Response) todoIntro() gtpl.Template {
 }
 
 func (s *Response) improvementIntro() gtpl.Template {
-	adj := "one thought"
+	adj := "is one thought"
 	if 1 < len(s.improvement) {
-		adj = "some thoughts"
+		adj = "are some thoughts"
 	}
 	return gtpl.Improvement.Format(adj)
 }


### PR DESCRIPTION
Exalysis is fantastic, thank you so much for doing this!

I noticed a small glitch in the output for suggested improvements:

`Here one thought for further improvement...`

This commit fixes it to say "Here *is* (here *are*)..."