### PR TITLE
docs: tweak the verbiage of the golint tip

### DIFF
--- a/gtpl/tools/not_linted.md
+++ b/gtpl/tools/not_linted.md
@@ -1,3 +1,3 @@
-- There's a great tool called [`golint`](https://github.com/golang/lint) which will examine your code for common problems and style issues. Try running `golint` on your code; it will make some useful suggestions for you.
+- There's a great tool called [`golint`](https://github.com/golang/lint) which will examine your code for common problems and style issues. Try running `golint` on your code, e.g.: `golint two_fer.go`; it will make some useful suggestions for you.
 
-    Try to get into the habit of always checking your code with `golint` (or configuring your editor to do it for you). When you're writing Go software for production, many build pipelines will fail commits automatically if they don't pass `golint` (and `gofmt`). Avoid this by linting code yourself!
+    It's a good idea to always check your code with `golint` (or configure your editor to do it for you). When you're writing Go software for production, many build pipelines will automatically fail if the code doesn't pass `golint` (and `gofmt`). You can avoid this by linting code yourself prior to submitting it.


### PR DESCRIPTION
This adds an example invocation of `golint` and attempts to "soften" the imperative tone of the second paragraph a bit.